### PR TITLE
Update OpenClick use of get_body()

### DIFF
--- a/src/consume-mail.py
+++ b/src/consume-mail.py
@@ -336,7 +336,7 @@ class MyHTMLClickParser(HTMLParser):
 # takes a persistent requests session object
 def openClickMail(mail, probs, shareRes, s, openClickTimeout, userAgent, trackingDomainsAllowlist):
     ll = ''
-    bd = mail.get_body('text/html')
+    bd = mail.get_body(('html',))
     if bd:  # if no body to parse, ignore
         body = bd.get_content()                             # this handles quoted-printable type for us
         htmlOpenParser = MyHTMLOpenParser(s, shareRes, openClickTimeout, userAgent, trackingDomainsAllowlist)


### PR DESCRIPTION
Updating the argument to a tuple containing an allowed value.
 https://docs.python.org/3.6/library/email.message.html#email.message.EmailMessage.get_body

Per the doc:
preferencelist must be a sequence of strings from the set related, html, and plain, and indicates the order of preference for the content type of the part returned.

The method also expects a list, and may have unexpected results passing a string:
https://github.com/python/cpython/blob/0a0a135bae2692d069b18d2d590397fbe0a0d39a/Lib/email/message.py#L1006